### PR TITLE
Refactored HttpRequest into two new classes HttpRequest and HttpResponse

### DIFF
--- a/common/utils/utils.cpp
+++ b/common/utils/utils.cpp
@@ -292,6 +292,15 @@ namespace Aseba
 		return split<std::wstring>(s, L"\t ");
 	}
 	
+    std::string trim(const std::string& s)
+    {
+        static const char *whitespaceChars = "\n\r\t ";
+        std::string::size_type start = s.find_first_not_of(whitespaceChars);
+        std::string::size_type end = s.find_last_not_of(whitespaceChars);
+
+        return start != std::string::npos ? s.substr(start, 1 + end - start) : "";
+    }
+
 	template<typename T>
 	T join(typename std::vector<T>::const_iterator first, typename std::vector<T>::const_iterator last, const T& delim)
 	{

--- a/common/utils/utils.h
+++ b/common/utils/utils.h
@@ -130,6 +130,9 @@ namespace Aseba
 	template<typename T>
 	std::vector<T> split(const T& s);
 	
+	//! Trims whitespaces from a string
+	std::string trim(const std::string& s);
+
 	//! Join a sequence using operator += and adding delim in-between elements
 	template<typename T>
 	T join(typename std::vector<T>::const_iterator first, typename std::vector<T>::const_iterator last, const T& delim);

--- a/switches/http/CMakeLists.txt
+++ b/switches/http/CMakeLists.txt
@@ -10,6 +10,7 @@ if (LIBXML2_FOUND)
 	set(http_SRCS
 		http.cpp
 		main.cpp
+		HttpRequest.cpp
 	)
 	set(http_MOCS
 		http.h

--- a/switches/http/CMakeLists.txt
+++ b/switches/http/CMakeLists.txt
@@ -11,6 +11,7 @@ if (LIBXML2_FOUND)
 		http.cpp
 		main.cpp
 		HttpRequest.cpp
+		HttpResponse.cpp
 	)
 	set(http_MOCS
 		http.h

--- a/switches/http/HttpRequest.cpp
+++ b/switches/http/HttpRequest.cpp
@@ -1,0 +1,210 @@
+/*
+	Aseba - an event-based framework for distributed robot control
+	Copyright (C) 2007--2015:
+		Stephane Magnenat <stephane at magnenat dot net>
+		(http://stephane.magnenat.net)
+		and other contributors, see authors.txt for details
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, version 3 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <iostream>
+#include "HttpRequest.h"
+#include "HttpResponse.h"
+#include "../../common/utils/utils.h"
+
+using Aseba::DashelHttpRequest;
+using Aseba::DashelHttpResponse;
+using Aseba::HttpRequest;
+using Aseba::HttpResponse;
+using std::cerr;
+using std::endl;
+using std::map;
+using std::string;
+using std::vector;
+
+HttpRequest::HttpRequest() :
+	verbose(false),
+	valid(false),
+	blocking(false),
+	response(NULL)
+{
+
+}
+
+HttpRequest::~HttpRequest()
+{
+	delete response;
+}
+
+
+bool HttpRequest::receive()
+{
+	valid = false;
+
+	if(!readRequestLine()) {
+		return false;
+	}
+
+	if(!readHeaders()) {
+		return false;
+	}
+
+	if(!readContent()) {
+		return false;
+	}
+
+	valid = true;
+
+	if(verbose) {
+		cerr << this << " Received valid " << getProtocol() << " " << getMethod() << " request for " << getUri() << " with " << content.size() << " byte(s) payload ";
+
+		cerr << "(headers:";
+
+		map<string, string>::const_iterator end = headers.end();
+		for(map<string, string>::const_iterator iter = headers.begin(); iter != end; ++iter) {
+			cerr << " " << iter->first << "=" << iter->second;
+		}
+
+		cerr << ")" << endl;
+	}
+
+	return true;
+}
+
+HttpResponse& HttpRequest::respond()
+{
+	if(response == NULL) {
+		response = createResponse();
+		response->setVerbose(verbose);
+	}
+
+	return *response;
+}
+
+bool HttpRequest::readRequestLine()
+{
+	string requestLine = readLine();
+	vector<string> parts = split<string>(requestLine, " ");
+
+	if(parts.size() != 3) {
+		return false;
+	}
+
+	method = parts[0];
+	uri = parts[1];
+	protocol = trim(parts[2]);
+
+	if(!(method.find("GET", 0) == 0 || method.find("PUT", 0) == 0 || method.find("POST", 0) == 0 || method.find("OPTIONS", 0) == 0)) {
+		return false;
+	}
+
+	if(!(protocol == "HTTP/1.0" || protocol == "HTTP/1.1")) {
+		return false;
+	}
+
+	// Also allow %2F as URL part delimiter (see Scratch v430)
+	std::string::size_type n = 0;
+	while((n = uri.find("%2F", n)) != std::string::npos) {
+		uri.replace(n, 3, "/"), n += 1;
+	}
+
+	tokens = split<string>(uri, "/");
+	// eat leading empty tokens, but leave at least one
+	while(tokens.size() > 1 && tokens[0].size() == 0) {
+		tokens.erase(tokens.begin(), tokens.begin() + 1);
+	}
+
+	return true;
+}
+
+bool HttpRequest::readHeaders()
+{
+	headers.clear();
+
+	while(true) {
+		const string headerLine(trim(readLine()));
+
+		if(headerLine.empty()) { // header section ends with empty line
+			break;
+		}
+
+		size_t firstColon = headerLine.find(": ");
+
+		if(firstColon != string::npos) {
+			string header = headerLine.substr(0, firstColon);
+			string value = headerLine.substr(firstColon + 2);
+
+			headers[header] = value;
+		} else {
+			if(verbose) {
+				cerr << this << " Invalid header line: " << headerLine << endl;
+			}
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool HttpRequest::readContent()
+{
+	// to make our life easier, we will require the presence of Content-Length in order to parse content
+	int contentLength = atoi(headers["Content-Length"].c_str());
+	contentLength = (contentLength > CONTENT_BYTES_LIMIT) ? CONTENT_BYTES_LIMIT : contentLength; // truncate at limit
+
+	if(contentLength > 0) {
+		char *buffer = new char[contentLength];
+		readRaw(buffer, contentLength);
+		content = string(buffer, contentLength);
+		delete[] buffer;
+	} else {
+		content = "";
+	}
+
+	return true;
+}
+
+DashelHttpRequest::DashelHttpRequest(Dashel::Stream *stream_) :
+	stream(stream_)
+{
+
+
+}
+
+DashelHttpRequest::~DashelHttpRequest()
+{
+
+}
+
+HttpResponse *DashelHttpRequest::createResponse()
+{
+	return new DashelHttpResponse(this);
+}
+
+std::string DashelHttpRequest::readLine()
+{
+	char c;
+	std::string line;
+	do {
+		stream->read(&c, 1);
+		line += c;
+	} while(c != '\n');
+
+	return line;
+}
+
+void DashelHttpRequest::readRaw(char *buffer, int size)
+{
+	stream->read(buffer, size);
+}

--- a/switches/http/HttpRequest.h
+++ b/switches/http/HttpRequest.h
@@ -1,0 +1,111 @@
+/*
+	Aseba - an event-based framework for distributed robot control
+	Copyright (C) 2007--2015:
+		Stephane Magnenat <stephane at magnenat dot net>
+		(http://stephane.magnenat.net)
+		and other contributors, see authors.txt for details
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, version 3 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ASEBA_HTTP_REQUEST
+#define ASEBA_HTTP_REQUEST
+
+#include <map>
+#include <string>
+#include <vector>
+#include <dashel/dashel.h>
+
+namespace Aseba
+{
+	class HttpResponse; // forward declaration
+
+	class HttpRequest
+	{
+		public:
+			static const int CONTENT_BYTES_LIMIT = 40000;
+
+			HttpRequest();
+			virtual ~HttpRequest();
+
+			virtual bool receive();
+			virtual HttpResponse& respond();
+
+			virtual bool isResponseReady() const { return !blocking && response != NULL; }
+
+			virtual void setVerbose(bool verbose) { this->verbose = verbose; }
+			virtual bool isValid() const { return valid; }
+			virtual void setBlocking(bool blocking) { this->blocking = blocking; }
+			virtual bool isBlocking() { return blocking; }
+
+			virtual const std::string& getMethod() const { return method; }
+			virtual const std::string& getUri() const { return uri; }
+			virtual const std::string& getProtocol() const { return protocol; }
+			virtual const std::vector<std::string>& getTokens() const { return tokens; }
+			virtual const std::map<std::string, std::string>& getHeaders() const { return headers; }
+			virtual const std::string& getContent() const { return content; }
+
+			std::string getHeader(const std::string& header) const {
+				std::map<std::string, std::string>::const_iterator query = headers.find(header);
+
+				if(query != headers.end()) {
+					return query->second;
+				} else {
+					return "";
+				}
+			}
+
+		protected:
+			virtual bool readRequestLine();
+			virtual bool readHeaders();
+			virtual bool readContent();
+
+			virtual HttpResponse *createResponse() = 0;
+
+			virtual std::string readLine() = 0;
+			virtual void readRaw(char *buffer, int size) = 0;
+
+		private:
+			bool verbose;
+			bool valid;
+			bool blocking;
+			HttpResponse *response;
+
+			std::string method;
+			std::string uri;
+			std::string protocol;
+			std::vector<std::string> tokens;
+			std::map<std::string, std::string> headers;
+			std::string content;
+	};
+
+	class DashelHttpRequest : public HttpRequest
+	{
+		public:
+    		DashelHttpRequest(Dashel::Stream *stream);
+			virtual ~DashelHttpRequest();
+
+			virtual Dashel::Stream *getStream() { return stream; }
+
+		protected:
+			virtual HttpResponse *createResponse();
+
+			virtual std::string readLine();
+			virtual void readRaw(char *buffer, int size);
+
+		private:
+			Dashel::Stream *stream;
+	};
+}
+
+#endif

--- a/switches/http/HttpResponse.cpp
+++ b/switches/http/HttpResponse.cpp
@@ -119,7 +119,9 @@ void HttpResponse::addHeadersReply(std::ostringstream& reply)
 	map<string, string>::const_iterator end = headers.end();
 	for(map<string, string>::const_iterator iter = headers.begin(); iter != end; ++iter) {
 		if(iter->first == "Content-Length") { // override with actual size
-			reply << iter->first << ": " << content.size() << "\r\n";
+			if(getHeader("Content-Type") != "text/event-stream") { // but only if this is not an event stream
+				reply << iter->first << ": " << content.size() << "\r\n";
+			}
 		} else {
 			reply << iter->first << ": " << iter->second << "\r\n";
 		}

--- a/switches/http/HttpResponse.cpp
+++ b/switches/http/HttpResponse.cpp
@@ -1,0 +1,129 @@
+/*
+	Aseba - an event-based framework for distributed robot control
+	Copyright (C) 2007--2015:
+		Stephane Magnenat <stephane at magnenat dot net>
+		(http://stephane.magnenat.net)
+		and other contributors, see authors.txt for details
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, version 3 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <iostream>
+#include "HttpResponse.h"
+
+using Aseba::HttpRequest;
+using Aseba::HttpResponse;
+using std::cerr;
+using std::endl;
+using std::map;
+using std::ostringstream;
+using std::string;
+
+HttpResponse::HttpResponse(const HttpRequest *originatingRequest_) :
+	originatingRequest(originatingRequest_),
+	verbose(false),
+	status(HTTP_STATUS_OK)
+{
+	// add some default headers, these can be overwritten later
+	setHeader("Content-Length", "");
+	setHeader("Content-Type", "application/json");
+	setHeader("Access-Control-Allow-Origin", "*");
+
+	if(originatingRequest->getHeader("Connection") == "keep-alive") {
+		setHeader("Connection", "keep-alive");
+	}
+}
+
+HttpResponse::~HttpResponse()
+{
+
+}
+
+void HttpResponse::send()
+{
+	// send reply with status and headers first
+	ostringstream reply;
+
+	addStatusReply(reply);
+	addHeadersReply(reply);
+
+	std::string replyString(reply.str());
+	writeRaw(replyString.c_str(), replyString.size());
+
+	// send content payload second
+	writeRaw(content.c_str(), content.size());
+
+	if(verbose) {
+		cerr << getOriginatingRequest() << " Sent HTTP response with status " << status << " and " << content.size() << " byte(s) payload" << endl;
+	}
+}
+
+void HttpResponse::addStatusReply(std::ostringstream& reply)
+{
+	if(originatingRequest->getProtocol() == "HTTP/1.0" || originatingRequest->getProtocol() == "HTTP/1.1") {
+		reply << originatingRequest->getProtocol();
+	} else {
+		reply << "HTTP/1.1";
+	}
+
+	reply << " " << status << " ";
+
+	switch(status) {
+		case HTTP_STATUS_OK:
+			reply << "OK";
+		break;
+		case HTTP_STATUS_CREATED:
+			reply << "Created";
+		break;
+		case HTTP_STATUS_BAD_REQUEST:
+			reply << "Bad Request";
+		break;
+		case HTTP_STATUS_FORBIDDEN:
+			reply << "Forbidden";
+		break;
+		case HTTP_STATUS_NOT_FOUND:
+			reply << "Not Found";
+		break;
+		case HTTP_STATUS_REQUEST_TIMEOUT:
+			reply << "Request Timeout";
+		break;
+		case HTTP_STATUS_INTERNAL_SERVER_ERROR:
+			reply << "Internal Server Error";
+		break;
+		case HTTP_STATUS_NOT_IMPLEMENTED:
+			reply << "Not Implemented";
+		break;
+		case HTTP_STATUS_SERVICE_UNAVAILABLE:
+			reply << "Service Unavailable";
+		break;
+		default:
+			reply << "Unknown";
+		break;
+	}
+
+	reply << "\r\n";
+}
+
+void HttpResponse::addHeadersReply(std::ostringstream& reply)
+{
+	map<string, string>::const_iterator end = headers.end();
+	for(map<string, string>::const_iterator iter = headers.begin(); iter != end; ++iter) {
+		if(iter->first == "Content-Length") { // override with actual size
+			reply << iter->first << ": " << content.size() << "\r\n";
+		} else {
+			reply << iter->first << ": " << iter->second << "\r\n";
+		}
+	}
+
+	reply << "\r\n";
+}

--- a/switches/http/HttpResponse.h
+++ b/switches/http/HttpResponse.h
@@ -1,0 +1,113 @@
+/*
+	Aseba - an event-based framework for distributed robot control
+	Copyright (C) 2007--2015:
+		Stephane Magnenat <stephane at magnenat dot net>
+		(http://stephane.magnenat.net)
+		and other contributors, see authors.txt for details
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, version 3 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ASEBA_HTTP_RESPONSE
+#define ASEBA_HTTP_RESPONSE
+
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <dashel/dashel.h>
+
+#include "HttpRequest.h"
+
+namespace Aseba
+{
+	class HttpResponse
+	{
+		public:
+			typedef enum {
+				HTTP_STATUS_OK = 200,
+				HTTP_STATUS_CREATED = 201,
+				HTTP_STATUS_BAD_REQUEST = 400,
+				HTTP_STATUS_FORBIDDEN = 403,
+				HTTP_STATUS_NOT_FOUND = 404,
+				HTTP_STATUS_REQUEST_TIMEOUT = 408,
+				HTTP_STATUS_INTERNAL_SERVER_ERROR = 500,
+				HTTP_STATUS_NOT_IMPLEMENTED = 501,
+				HTTP_STATUS_SERVICE_UNAVAILABLE = 503,
+			} HttpStatus;
+
+			HttpResponse(const HttpRequest *originatingRequest);
+			virtual ~HttpResponse();
+
+			virtual void send();
+
+			virtual const HttpRequest *getOriginatingRequest() const { return originatingRequest; }
+			virtual void setVerbose(bool verbose) { this->verbose = verbose; }
+
+			virtual void setStatus(HttpStatus status) { this->status = status; }
+			virtual HttpStatus getStatus() const { return status; }
+			virtual void setHeader(const std::string& header, const std::string& value) { headers[header] = value; }
+			virtual const std::map<std::string, std::string>& getHeaders() const { return headers; }
+			virtual void setContent(const std::string& content) { this->content = content; }
+			virtual const std::string& getContent() const { return content; }
+
+			std::string getHeader(const std::string& header) const {
+				std::map<std::string, std::string>::const_iterator query = headers.find(header);
+
+				if(query != headers.end()) {
+					return query->second;
+				} else {
+					return "";
+				}
+			}
+
+		protected:
+			virtual void addStatusReply(std::ostringstream& reply);
+			virtual void addHeadersReply(std::ostringstream& reply);
+
+			virtual void writeRaw(const char *buffer, int length) = 0;
+
+		private:
+			const HttpRequest *originatingRequest;
+			bool verbose;
+
+			HttpStatus status;
+			std::map<std::string, std::string> headers;
+			std::string content;
+	};
+
+	class DashelHttpResponse : public HttpResponse
+	{
+		public:
+			DashelHttpResponse(DashelHttpRequest *originatingRequest) :
+				HttpResponse(originatingRequest),
+				stream(originatingRequest->getStream())
+			{
+
+			}
+
+			virtual ~DashelHttpResponse() {}
+
+		protected:
+			virtual void writeRaw(const char *buffer, int length)
+			{
+				stream->write(buffer, length);
+				stream->flush();
+			}
+
+		private:
+			Dashel::Stream *stream;
+	};
+}
+
+#endif

--- a/switches/http/http.cpp
+++ b/switches/http/http.cpp
@@ -658,6 +658,7 @@ namespace Aseba
         req->respond().setHeader("Content-Type", "text/event-stream");
         req->respond().setHeader("Cache-Control", "no-cache");
         req->respond().setHeader("Connection", "keep-alive");
+        req->respond().send(); // send header immediately
         req->setBlocking(true); // connection must stay open!
     }
     

--- a/switches/http/http.cpp
+++ b/switches/http/http.cpp
@@ -421,7 +421,9 @@ namespace Aseba
                 if (subscriber->second.count("*") >= 1 || subscriber->second.count(event_name) >= 1)
                 {
                 	std::string replyString(reply.str());
-                	static_cast<DashelHttpRequest *>(subscriber->first)->getStream()->write(replyString.c_str(), replyString.size());
+                	Dashel::Stream *stream = static_cast<DashelHttpRequest *>(subscriber->first)->getStream();
+                	stream->write(replyString.c_str(), replyString.size());
+                	stream->flush();
                 }
             }
         }


### PR DESCRIPTION
Hi David,

I started refactoring some of the asebahttp code and started with the `HttpRequest` class. I wasn't very happy about how parsing requests and sending responses was mixed in that class, so I cleanly seperated those two things into two new classes called `HttpRequest` and `HttpResponse`. Incoming requests start out without a `HttpResponse` and are stalled in `HttpInterface::sendAvailableResponses()` until a response was created by using `HttpRequest`'s new `respond()` method. Since a request can have only one response, calling `respond()` repeatedly will simply return a reference to the same response, which makes it very easy to add things like multiple output headers.

I took special care not to touch any of the routing and response generation logic in `HttpInterface` (yet), so everything should still function exactly as it used to. The same goes for the tests in test-http, except that testing the parsing from a string input is now even easier and works even without a `Dashel::Stream`.

I have more changes like this coming, but I thought I can already send you a PR for this one :)

Best,
Fabian
