### PR TITLE
Refactored HTTP request routing and handling into new HttpHandler classes

### DIFF
--- a/common/utils/utils.cpp
+++ b/common/utils/utils.cpp
@@ -292,6 +292,15 @@ namespace Aseba
 		return split<std::wstring>(s, L"\t ");
 	}
 	
+    std::string trim(const std::string& s)
+    {
+        static const char *whitespaceChars = "\n\r\t ";
+        std::string::size_type start = s.find_first_not_of(whitespaceChars);
+        std::string::size_type end = s.find_last_not_of(whitespaceChars);
+
+        return start != std::string::npos ? s.substr(start, 1 + end - start) : "";
+    }
+
 	template<typename T>
 	T join(typename std::vector<T>::const_iterator first, typename std::vector<T>::const_iterator last, const T& delim)
 	{

--- a/common/utils/utils.h
+++ b/common/utils/utils.h
@@ -130,6 +130,9 @@ namespace Aseba
 	template<typename T>
 	std::vector<T> split(const T& s);
 	
+	//! Trims whitespaces from a string
+	std::string trim(const std::string& s);
+
 	//! Join a sequence using operator += and adding delim in-between elements
 	template<typename T>
 	T join(typename std::vector<T>::const_iterator first, typename std::vector<T>::const_iterator last, const T& delim);

--- a/switches/http/CMakeLists.txt
+++ b/switches/http/CMakeLists.txt
@@ -10,6 +10,7 @@ if (LIBXML2_FOUND)
 	set(http_SRCS
 		http.cpp
 		main.cpp
+		HttpRequest.cpp
 	)
 	set(http_MOCS
 		http.h

--- a/switches/http/CMakeLists.txt
+++ b/switches/http/CMakeLists.txt
@@ -10,6 +10,7 @@ if (LIBXML2_FOUND)
 	set(http_SRCS
 		http.cpp
 		main.cpp
+		HttpInterfaceHandlers.cpp
 		HttpRequest.cpp
 		HttpResponse.cpp
 	)

--- a/switches/http/CMakeLists.txt
+++ b/switches/http/CMakeLists.txt
@@ -11,6 +11,7 @@ if (LIBXML2_FOUND)
 		http.cpp
 		main.cpp
 		HttpRequest.cpp
+		HttpResponse.cpp
 	)
 	set(http_MOCS
 		http.h

--- a/switches/http/HttpHandler.h
+++ b/switches/http/HttpHandler.h
@@ -1,0 +1,160 @@
+/*
+	Aseba - an event-based framework for distributed robot control
+	Copyright (C) 2007--2015:
+		Stephane Magnenat <stephane at magnenat dot net>
+		(http://stephane.magnenat.net)
+		and other contributors, see authors.txt for details
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, version 3 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ASEBA_HTTP_HANDLER
+#define ASEBA_HTTP_HANDLER
+
+#include <cassert>
+#include <string>
+#include <vector>
+#include "HttpRequest.h"
+#include "HttpResponse.h"
+
+namespace Aseba
+{
+	class HttpInterface; // forward declaration
+
+	/**
+	 * Base class for HTTP handlers.
+	 * Intended to be used with multiple inheritance, so make sure to always virtually inheriting from it.
+	 */
+
+	class HttpHandler
+	{
+		public:
+			HttpHandler() { }
+			virtual ~HttpHandler() { }
+
+			virtual bool checkIfResponsible(HttpRequest *request, const std::vector<std::string>& tokens) const = 0;
+			virtual void handleRequest(HttpRequest *request, const std::vector<std::string>& tokens) = 0;
+	};
+
+	class InterfaceHttpHandler : public virtual HttpHandler
+	{
+		public:
+			InterfaceHttpHandler(HttpInterface *interface_) :
+				interface(interface_)
+			{
+
+			}
+
+			virtual const HttpInterface *getInterface() const { return interface; }
+
+		protected:
+			virtual HttpInterface *getInterface() { return interface; }
+
+		private:
+			HttpInterface *interface;
+	};
+
+	class WildcardHttpHandler : public virtual HttpHandler
+	{
+		public:
+			WildcardHttpHandler() { }
+			virtual ~WildcardHttpHandler() { }
+
+			virtual bool checkIfResponsible(HttpRequest *request, const std::vector<std::string>& tokens) const { return true; }
+	};
+
+	class HierarchicalHttpHandler : public virtual HttpHandler
+	{
+		public:
+			HierarchicalHttpHandler() { }
+
+			virtual ~HierarchicalHttpHandler()
+			{
+				for(int i = 0; i < getNumSubhandlers(); i++)
+				{
+					delete subhandlers[i];
+				}
+			}
+
+			virtual void handleRequest(HttpRequest *request, const std::vector<std::string>& tokens)
+			{
+				for(int i = 0; i < getNumSubhandlers(); i++) {
+					if(subhandlers[i]->checkIfResponsible(request, tokens)) {
+						subhandlers[i]->handleRequest(request, tokens);
+						return;
+					}
+				}
+
+				request->respond().setStatus(HttpResponse::HTTP_STATUS_NOT_FOUND);
+			}
+
+			virtual void addSubhandler(HttpHandler *subhandler) { subhandlers.push_back(subhandler); }
+			virtual int getNumSubhandlers() const { return (int) subhandlers.size(); }
+
+		private:
+			std::vector<HttpHandler *> subhandlers;
+	};
+
+	class RootHttpHandler : public WildcardHttpHandler, public HierarchicalHttpHandler
+	{
+		public:
+			RootHttpHandler() { }
+			virtual ~RootHttpHandler() { }
+	};
+
+	class TokenHttpHandler : public virtual HttpHandler
+	{
+		public:
+			TokenHttpHandler() { }
+			virtual ~TokenHttpHandler() { }
+
+			virtual bool checkIfResponsible(HttpRequest *request, const std::vector<std::string>& tokens) const
+			{
+				if(tokens.empty()) {
+					return false;
+				}
+
+				for(int i = 0; i < getNumTokens(); i++) {
+					if(this->tokens[i] == tokens[0]) {
+						return true;
+					}
+				}
+
+				return false;
+			}
+
+			virtual void addToken(const std::string& token) { tokens.push_back(token); }
+			virtual const std::vector<std::string>& getTokens() const { return tokens; }
+			virtual int getNumTokens() const { return (int) tokens.size(); }
+
+		private:
+			std::vector<std::string> tokens;
+	};
+
+	class HierarchicalTokenHttpHandler : public HierarchicalHttpHandler, public TokenHttpHandler
+	{
+		public:
+			HierarchicalTokenHttpHandler() { }
+			virtual ~HierarchicalTokenHttpHandler() { }
+
+			virtual void handleRequest(HttpRequest *request, const std::vector<std::string>& tokens)
+			{
+				assert(!tokens.empty());
+				std::vector<std::string> newTokens(tokens.begin() + 1, tokens.end()); // eat first token
+
+				HierarchicalHttpHandler::handleRequest(request, newTokens);
+			}
+	};
+}
+
+#endif

--- a/switches/http/HttpInterfaceHandlers.cpp
+++ b/switches/http/HttpInterfaceHandlers.cpp
@@ -1,0 +1,367 @@
+/*
+	Aseba - an event-based framework for distributed robot control
+	Copyright (C) 2007--2015:
+		Stephane Magnenat <stephane at magnenat dot net>
+		(http://stephane.magnenat.net)
+		and other contributors, see authors.txt for details
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, version 3 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <iostream>
+#include "../../common/utils/utils.h"
+#include "http.h"
+#include "HttpInterfaceHandlers.h"
+
+using Aseba::EventsHandler;
+using Aseba::HttpInterface;
+using Aseba::InterfaceHttpHandler;
+using Aseba::LoadHandler;
+using Aseba::NodeEventsHandler;
+using Aseba::NodeInfoHandler;
+using Aseba::NodesHandler;
+using Aseba::ResetHandler;
+using Aseba::VariableOrEventHandler;
+using std::cerr;
+using std::endl;
+using std::string;
+using std::vector;
+
+NodesHandler::NodesHandler(HttpInterface *interface) :
+	InterfaceHttpHandler(interface)
+{
+	addToken("nodes");
+
+	addSubhandler(new LoadHandler(interface));
+	addSubhandler(new NodeInfoHandler(interface));
+	addSubhandler(new NodeEventsHandler(interface));
+	addSubhandler(new VariableOrEventHandler(interface));
+}
+
+NodesHandler::~NodesHandler()
+{
+
+}
+
+EventsHandler::EventsHandler(HttpInterface *interface) :
+	InterfaceHttpHandler(interface)
+{
+	addToken("events");
+}
+
+EventsHandler::~EventsHandler()
+{
+
+}
+
+void EventsHandler::handleRequest(HttpRequest *request, const std::vector<std::string>& tokens)
+{
+	// eventSubscriptions[conn] is an unordered set of strings
+	if(tokens.size() == 1) {
+		getInterface()->getEventSubscriptions()[request].insert("*");
+	} else {
+		for(vector<string>::const_iterator i = tokens.begin() + 1; i != tokens.end(); ++i) {
+			getInterface()->getEventSubscriptions()[request].insert(*i);
+		}
+	}
+
+	request->respond().setHeader("Content-Type", "text/event-stream");
+	request->respond().setHeader("Cache-Control", "no-cache");
+	request->respond().setHeader("Connection", "keep-alive");
+	request->respond().send(); // send header immediately
+	request->setBlocking(true); // connection must stay open!
+}
+
+ResetHandler::ResetHandler(HttpInterface *interface) :
+	InterfaceHttpHandler(interface)
+{
+	addToken("reset");
+	addToken("reset_all");
+}
+
+ResetHandler::~ResetHandler()
+{
+
+}
+
+void ResetHandler::handleRequest(HttpRequest *request, const std::vector<std::string>& tokens)
+{
+	for(HttpInterface::NodesDescriptionsMap::iterator descIt = getInterface()->getNodesDescriptions().begin(); descIt != getInterface()->getNodesDescriptions().end(); ++descIt) {
+		bool ok = true;
+		// nodeId = getNodeId(descIt->second.name, 0, &ok);
+		if(!ok) continue;
+		string nodeName = WStringToUTF8(descIt->second.name);
+
+		for(HttpInterface::StreamNodeIdMap::iterator it = getInterface()->getAsebaStreams().begin(); it != getInterface()->getAsebaStreams().end(); ++it) {
+			Dashel::Stream* stream = it->first;
+			unsigned nodeId = it->second;
+			Reset(nodeId).serialize(stream); // reset node
+			stream->flush();
+			Run(nodeId).serialize(stream);   // re-run node
+			stream->flush();
+			if(descIt->second.name.find(L"thymio-II") == 0) {   // Special case for Thymio-II. Should we instead just check whether motor.*.target exists?
+				vector<string> tokens;
+				tokens.push_back("motor.left.target");
+				tokens.push_back("0");
+				getInterface()->sendSetVariable(nodeId, tokens);
+				tokens[0] = "motor.right.target";
+				getInterface()->sendSetVariable(nodeId, tokens);
+			}
+			size_t eventPos;
+			if(getInterface()->getCommonDefinitions()[nodeId].events.contains(UTF8ToWString("reset"), &eventPos)) {
+				// bug: assumes AESL file is common to all nodes
+				// can we get this from the node description?
+				vector<string> data;
+				data.push_back("reset");
+				getInterface()->sendEvent(nodeId, data);
+			}
+		}
+
+		request->respond();
+	}
+}
+
+LoadHandler::LoadHandler(HttpInterface *interface) :
+	InterfaceHttpHandler(interface)
+{
+
+}
+
+LoadHandler::~LoadHandler()
+{
+
+}
+
+bool LoadHandler::checkIfResponsible(HttpRequest *request, const std::vector<std::string>& tokens) const
+{
+	return tokens.size() <= 1 && request->getMethod() == "PUT";
+}
+
+void LoadHandler::handleRequest(HttpRequest *request, const std::vector<std::string>& tokens)
+{
+	if(getInterface()->isVerbose()) {
+		cerr << "PUT /nodes/" << tokens[0].c_str() << " trying to load aesl script\n";
+	}
+
+	const char* buffer = request->getContent().c_str();
+	size_t pos = request->getContent().find("file=");
+	if(pos != std::string::npos) {
+		std::vector<unsigned> todo = getInterface()->getIdsFromArgs(tokens);
+		for(std::vector<unsigned>::const_iterator it = todo.begin(); it != todo.end(); ++it) {
+			getInterface()->aeslLoadMemory(*it, buffer + pos + 5, request->getContent().size() - pos - 5);
+		}
+		request->respond();
+	} else {
+		request->respond().setStatus(HttpResponse::HTTP_STATUS_BAD_REQUEST);
+	}
+}
+
+NodeEventsHandler::NodeEventsHandler(HttpInterface *interface) :
+	InterfaceHttpHandler(interface)
+{
+
+}
+
+NodeEventsHandler::~NodeEventsHandler()
+{
+
+}
+
+bool NodeEventsHandler::checkIfResponsible(HttpRequest *request, const std::vector<std::string>& tokens) const
+{
+	return tokens.size() >= 2 && tokens[1].find("events") == 0;
+}
+
+void NodeEventsHandler::handleRequest(HttpRequest *request, const std::vector<std::string>& tokens)
+{
+	// eventSubscriptions[conn] is an unordered set of strings
+	if(tokens.size() == 1) {
+		getInterface()->getEventSubscriptions()[request].insert("*");
+	} else {
+		for(vector<string>::const_iterator i = tokens.begin() + 1; i != tokens.end(); ++i) {
+			getInterface()->getEventSubscriptions()[request].insert(*i);
+		}
+	}
+
+	request->respond().setHeader("Content-Type", "text/event-stream");
+	request->respond().setHeader("Cache-Control", "no-cache");
+	request->respond().setHeader("Connection", "keep-alive");
+	request->respond().send(); // send header immediately
+	request->setBlocking(true); // connection must stay open!
+}
+
+NodeInfoHandler::NodeInfoHandler(HttpInterface *interface) :
+	InterfaceHttpHandler(interface)
+{
+
+}
+
+NodeInfoHandler::~NodeInfoHandler()
+{
+
+}
+
+bool NodeInfoHandler::checkIfResponsible(HttpRequest *request, const std::vector<std::string>& tokens) const
+{
+	return tokens.size() <= 1;
+}
+
+void NodeInfoHandler::handleRequest(HttpRequest *request, const std::vector<std::string>& tokens)
+{
+	bool do_one_node(tokens.size() > 0);
+
+	std::stringstream json;
+	json << (do_one_node ? "" : "["); // hack, should first select list of matching nodes, then check size
+
+	for(HttpInterface::NodesDescriptionsMap::iterator descIt = getInterface()->getNodesDescriptions().begin(); descIt != getInterface()->getNodesDescriptions().end(); ++descIt) {
+		const HttpInterface::NodeDescription& description(descIt->second);
+		string nodeName = WStringToUTF8(description.name);
+		unsigned nodeId = descIt->first;
+
+		if(!do_one_node) {
+			json << (descIt == getInterface()->getNodesDescriptions().begin() ? "" : ",");
+			json << "{";
+			json << "\"node\":" << nodeId << ",";
+			json << "\"name\":\"" << nodeName << "\",\"protocolVersion\":" << description.protocolVersion;
+			json << "}";
+		} else { // (do_one_node)
+			if(!(descIt->first == (unsigned) atoi(tokens[0].c_str()) || nodeName.find(tokens[0]) == 0)) continue; // this is not a match, skip to next candidate
+
+			json << "{"; // begin node
+			json << "\"node\":\"" << nodeId << "\",";
+			json << "\"name\":\"" << nodeName << "\",\"protocolVersion\":" << description.protocolVersion;
+
+			json << ",\"bytecodeSize\":" << description.bytecodeSize;
+			json << ",\"variablesSize\":" << description.variablesSize;
+			json << ",\"stackSize\":" << description.stackSize;
+
+			// named variables
+			json << ",\"namedVariables\":{";
+			bool seen_named_variables = false;
+			for(HttpInterface::NodeIdVariablesMap::const_iterator n(getInterface()->getAllVariables().find(nodeId)); n != getInterface()->getAllVariables().end(); ++n) {
+				VariablesMap vm = n->second;
+				for(VariablesMap::iterator i = vm.begin(); i != vm.end(); ++i) {
+					json << (i == vm.begin() ? "" : ",") << "\"" << WStringToUTF8(i->first) << "\":" << i->second.second;
+					seen_named_variables = true;
+				}
+			}
+			if(!seen_named_variables) {
+				// failsafe: if compiler hasn't found any variables, get them from the node description
+				for(vector<Aseba::TargetDescription::NamedVariable>::const_iterator i(description.namedVariables.begin()); i != description.namedVariables.end(); ++i)
+					json << (i == description.namedVariables.begin() ? "" : ",") << "\"" << WStringToUTF8(i->name) << "\":" << i->size;
+			}
+			json << "}";
+
+			// local events variables
+			json << ",\"localEvents\":{";
+			for(size_t i = 0; i < description.localEvents.size(); ++i) {
+				string ev(WStringToUTF8(description.localEvents[i].name));
+				json << (i == 0 ? "" : ",") << "\"" << ev << "\":" << "\"" << WStringToUTF8(description.localEvents[i].description) << "\"";
+			}
+			json << "}";
+
+			// constants from introspection
+			json << ",\"constants\":{";
+			for(size_t i = 0; i < getInterface()->getCommonDefinitions()[nodeId].constants.size(); ++i)
+				json << (i == 0 ? "" : ",") << "\"" << WStringToUTF8(getInterface()->getCommonDefinitions()[nodeId].constants[i].name) << "\":" << getInterface()->getCommonDefinitions()[nodeId].constants[i].value;
+			json << "}";
+
+			// events from introspection
+			json << ",\"events\":{";
+			for(size_t i = 0; i < getInterface()->getCommonDefinitions()[nodeId].events.size(); ++i)
+				json << (i == 0 ? "" : ",") << "\"" << WStringToUTF8(getInterface()->getCommonDefinitions()[nodeId].events[i].name) << "\":" << getInterface()->getCommonDefinitions()[nodeId].events[i].value;
+			json << "}";
+
+			json << "}"; // end node
+			break; // only show first matching node :-(
+		}
+	}
+
+	json << (do_one_node ? "" : "]");
+	if(json.str().size() == 0) json << "[]";
+
+	request->respond().setContent(json.str());
+}
+
+VariableOrEventHandler::VariableOrEventHandler(HttpInterface *interface) :
+	InterfaceHttpHandler(interface)
+{
+
+}
+
+VariableOrEventHandler::~VariableOrEventHandler()
+{
+
+}
+
+void VariableOrEventHandler::handleRequest(HttpRequest *request, const std::vector<std::string>& tokens)
+{
+	std::vector<unsigned> todo = getInterface()->getIdsFromArgs(tokens);
+	size_t eventPos;
+
+	for(std::vector<unsigned>::const_iterator it = todo.begin(); it != todo.end(); ++it) {
+		unsigned nodeId = *it;
+		if(!getInterface()->getCommonDefinitions()[nodeId].events.contains(UTF8ToWString(tokens[1]), &eventPos)) {
+			// this is a variable
+			if(request->getMethod().find("POST") == 0 || tokens.size() >= 3) {
+				// set variable value
+				vector<string> values;
+				if(tokens.size() >= 3) values.assign(tokens.begin() + 1, tokens.end());
+				else {
+					// Parse POST form data
+					values.push_back(tokens[1]);
+					getInterface()->parse_json_form(request->getContent(), values);
+				}
+				if(values.size() == 0) {
+					request->respond().setStatus(HttpResponse::HTTP_STATUS_NOT_FOUND);
+					if(getInterface()->isVerbose()) cerr << request << " evVariableOrEevent 404 can't set variable " << tokens[0] << ", no values" << endl;
+					continue;
+				}
+				getInterface()->sendSetVariable(nodeId, values);
+				request->respond();
+				if(getInterface()->isVerbose()) cerr << request << " evVariableOrEevent 200 set variable " << values[0] << endl;
+			} else {
+				// get variable value
+				vector<string> values;
+				values.assign(tokens.begin() + 1, tokens.begin() + 2);
+
+				unsigned start;
+				if(!getInterface()->getVarPos(nodeId, values[0], start)) {
+					request->respond().setStatus(HttpResponse::HTTP_STATUS_NOT_FOUND);
+					if(getInterface()->isVerbose()) cerr << request << " evVariableOrEevent 404 no such variable " << values[0] << endl;
+					continue;
+				}
+
+				getInterface()->sendGetVariables(nodeId, values);
+				getInterface()->getPendingVariables()[std::make_pair(nodeId, start)].insert(request);
+
+				if(getInterface()->isVerbose()) cerr << request << " evVariableOrEevent schedule var " << values[0] << "(" << nodeId << "," << start << ") add " << request << " to subscribers" << endl;
+				continue;
+			}
+		} else {
+			// this is an event
+			// arguments are tokens 1..N
+			vector<string> data;
+			data.push_back(tokens[1]);
+			if(tokens.size() >= 3) for(size_t i = 2; i < tokens.size(); ++i)
+				data.push_back((tokens[i].c_str()));
+			else if(request->getMethod().find("POST") == 0) {
+				// Parse POST form data
+				getInterface()->parse_json_form(std::string(request->getContent(), request->getContent().size()), data);
+			}
+			getInterface()->sendEvent(nodeId, data);
+			request->respond(); // or perhaps {"return_value":null,"cmd":"sendEvent","name":nodeName}?
+			continue;
+		}
+	}
+}

--- a/switches/http/HttpInterfaceHandlers.h
+++ b/switches/http/HttpInterfaceHandlers.h
@@ -1,0 +1,93 @@
+/*
+	Aseba - an event-based framework for distributed robot control
+	Copyright (C) 2007--2015:
+		Stephane Magnenat <stephane at magnenat dot net>
+		(http://stephane.magnenat.net)
+		and other contributors, see authors.txt for details
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, version 3 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ASEBA_HTTP_INTERFACE_HANDLERS
+#define ASEBA_HTTP_INTERFACE_HANDLERS
+
+#include "HttpHandler.h"
+
+namespace Aseba
+{
+	class NodesHandler : public HierarchicalTokenHttpHandler, public InterfaceHttpHandler
+	{
+		public:
+			NodesHandler(HttpInterface *interface);
+			virtual ~NodesHandler();
+	};
+
+	class EventsHandler : public TokenHttpHandler, public InterfaceHttpHandler
+	{
+		public:
+			EventsHandler(HttpInterface *interface);
+			virtual ~EventsHandler();
+
+			virtual void handleRequest(HttpRequest *request, const std::vector<std::string>& tokens);
+	};
+
+	class ResetHandler : public TokenHttpHandler, public InterfaceHttpHandler
+	{
+		public:
+			ResetHandler(HttpInterface *interface);
+			virtual ~ResetHandler();
+
+			virtual void handleRequest(HttpRequest *request, const std::vector<std::string>& tokens);
+	};
+
+	class LoadHandler : public virtual InterfaceHttpHandler
+	{
+		public:
+			LoadHandler(HttpInterface *interface);
+			virtual ~LoadHandler();
+
+			virtual bool checkIfResponsible(HttpRequest *request, const std::vector<std::string>& tokens) const;
+			virtual void handleRequest(HttpRequest *request, const std::vector<std::string>& tokens);
+	};
+
+	class NodeEventsHandler : public virtual InterfaceHttpHandler
+	{
+		public:
+			NodeEventsHandler(HttpInterface *interface);
+			virtual ~NodeEventsHandler();
+
+			virtual bool checkIfResponsible(HttpRequest *request, const std::vector<std::string>& tokens) const;
+			virtual void handleRequest(HttpRequest *request, const std::vector<std::string>& tokens);
+	};
+
+	class NodeInfoHandler : public virtual InterfaceHttpHandler
+	{
+		public:
+			NodeInfoHandler(HttpInterface *interface);
+			virtual ~NodeInfoHandler();
+
+			virtual bool checkIfResponsible(HttpRequest *request, const std::vector<std::string>& tokens) const;
+			virtual void handleRequest(HttpRequest *request, const std::vector<std::string>& tokens);
+	};
+
+	class VariableOrEventHandler : public virtual WildcardHttpHandler, public virtual InterfaceHttpHandler
+	{
+		public:
+			VariableOrEventHandler(HttpInterface *interface);
+			virtual ~VariableOrEventHandler();
+
+			virtual void handleRequest(HttpRequest *request, const std::vector<std::string>& tokens);
+	};
+}
+
+#endif

--- a/switches/http/HttpRequest.cpp
+++ b/switches/http/HttpRequest.cpp
@@ -1,0 +1,210 @@
+/*
+	Aseba - an event-based framework for distributed robot control
+	Copyright (C) 2007--2015:
+		Stephane Magnenat <stephane at magnenat dot net>
+		(http://stephane.magnenat.net)
+		and other contributors, see authors.txt for details
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, version 3 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <iostream>
+#include "HttpRequest.h"
+#include "HttpResponse.h"
+#include "../../common/utils/utils.h"
+
+using Aseba::DashelHttpRequest;
+using Aseba::DashelHttpResponse;
+using Aseba::HttpRequest;
+using Aseba::HttpResponse;
+using std::cerr;
+using std::endl;
+using std::map;
+using std::string;
+using std::vector;
+
+HttpRequest::HttpRequest() :
+	verbose(false),
+	valid(false),
+	blocking(false),
+	response(NULL)
+{
+
+}
+
+HttpRequest::~HttpRequest()
+{
+	delete response;
+}
+
+
+bool HttpRequest::receive()
+{
+	valid = false;
+
+	if(!readRequestLine()) {
+		return false;
+	}
+
+	if(!readHeaders()) {
+		return false;
+	}
+
+	if(!readContent()) {
+		return false;
+	}
+
+	valid = true;
+
+	if(verbose) {
+		cerr << this << " Received valid " << getProtocol() << " " << getMethod() << " request for " << getUri() << " with " << content.size() << " byte(s) payload ";
+
+		cerr << "(headers:";
+
+		map<string, string>::const_iterator end = headers.end();
+		for(map<string, string>::const_iterator iter = headers.begin(); iter != end; ++iter) {
+			cerr << " " << iter->first << "=" << iter->second;
+		}
+
+		cerr << ")" << endl;
+	}
+
+	return true;
+}
+
+HttpResponse& HttpRequest::respond()
+{
+	if(response == NULL) {
+		response = createResponse();
+		response->setVerbose(verbose);
+	}
+
+	return *response;
+}
+
+bool HttpRequest::readRequestLine()
+{
+	string requestLine = readLine();
+	vector<string> parts = split<string>(requestLine, " ");
+
+	if(parts.size() != 3) {
+		return false;
+	}
+
+	method = parts[0];
+	uri = parts[1];
+	protocol = trim(parts[2]);
+
+	if(!(method.find("GET", 0) == 0 || method.find("PUT", 0) == 0 || method.find("POST", 0) == 0 || method.find("OPTIONS", 0) == 0)) {
+		return false;
+	}
+
+	if(!(protocol == "HTTP/1.0" || protocol == "HTTP/1.1")) {
+		return false;
+	}
+
+	// Also allow %2F as URL part delimiter (see Scratch v430)
+	std::string::size_type n = 0;
+	while((n = uri.find("%2F", n)) != std::string::npos) {
+		uri.replace(n, 3, "/"), n += 1;
+	}
+
+	tokens = split<string>(uri, "/");
+	// eat leading empty tokens, but leave at least one
+	while(tokens.size() > 1 && tokens[0].size() == 0) {
+		tokens.erase(tokens.begin(), tokens.begin() + 1);
+	}
+
+	return true;
+}
+
+bool HttpRequest::readHeaders()
+{
+	headers.clear();
+
+	while(true) {
+		const string headerLine(trim(readLine()));
+
+		if(headerLine.empty()) { // header section ends with empty line
+			break;
+		}
+
+		size_t firstColon = headerLine.find(": ");
+
+		if(firstColon != string::npos) {
+			string header = headerLine.substr(0, firstColon);
+			string value = headerLine.substr(firstColon + 2);
+
+			headers[header] = value;
+		} else {
+			if(verbose) {
+				cerr << this << " Invalid header line: " << headerLine << endl;
+			}
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool HttpRequest::readContent()
+{
+	// to make our life easier, we will require the presence of Content-Length in order to parse content
+	int contentLength = atoi(headers["Content-Length"].c_str());
+	contentLength = (contentLength > CONTENT_BYTES_LIMIT) ? CONTENT_BYTES_LIMIT : contentLength; // truncate at limit
+
+	if(contentLength > 0) {
+		char *buffer = new char[contentLength];
+		readRaw(buffer, contentLength);
+		content = string(buffer, contentLength);
+		delete[] buffer;
+	} else {
+		content = "";
+	}
+
+	return true;
+}
+
+DashelHttpRequest::DashelHttpRequest(Dashel::Stream *stream_) :
+	stream(stream_)
+{
+
+
+}
+
+DashelHttpRequest::~DashelHttpRequest()
+{
+
+}
+
+HttpResponse *DashelHttpRequest::createResponse()
+{
+	return new DashelHttpResponse(this);
+}
+
+std::string DashelHttpRequest::readLine()
+{
+	char c;
+	std::string line;
+	do {
+		stream->read(&c, 1);
+		line += c;
+	} while(c != '\n');
+
+	return line;
+}
+
+void DashelHttpRequest::readRaw(char *buffer, int size)
+{
+	stream->read(buffer, size);
+}

--- a/switches/http/HttpRequest.h
+++ b/switches/http/HttpRequest.h
@@ -1,0 +1,111 @@
+/*
+	Aseba - an event-based framework for distributed robot control
+	Copyright (C) 2007--2015:
+		Stephane Magnenat <stephane at magnenat dot net>
+		(http://stephane.magnenat.net)
+		and other contributors, see authors.txt for details
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, version 3 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ASEBA_HTTP_REQUEST
+#define ASEBA_HTTP_REQUEST
+
+#include <map>
+#include <string>
+#include <vector>
+#include <dashel/dashel.h>
+
+namespace Aseba
+{
+	class HttpResponse; // forward declaration
+
+	class HttpRequest
+	{
+		public:
+			static const int CONTENT_BYTES_LIMIT = 40000;
+
+			HttpRequest();
+			virtual ~HttpRequest();
+
+			virtual bool receive();
+			virtual HttpResponse& respond();
+
+			virtual bool isResponseReady() const { return !blocking && response != NULL; }
+
+			virtual void setVerbose(bool verbose) { this->verbose = verbose; }
+			virtual bool isValid() const { return valid; }
+			virtual void setBlocking(bool blocking) { this->blocking = blocking; }
+			virtual bool isBlocking() { return blocking; }
+
+			virtual const std::string& getMethod() const { return method; }
+			virtual const std::string& getUri() const { return uri; }
+			virtual const std::string& getProtocol() const { return protocol; }
+			virtual const std::vector<std::string>& getTokens() const { return tokens; }
+			virtual const std::map<std::string, std::string>& getHeaders() const { return headers; }
+			virtual const std::string& getContent() const { return content; }
+
+			std::string getHeader(const std::string& header) const {
+				std::map<std::string, std::string>::const_iterator query = headers.find(header);
+
+				if(query != headers.end()) {
+					return query->second;
+				} else {
+					return "";
+				}
+			}
+
+		protected:
+			virtual bool readRequestLine();
+			virtual bool readHeaders();
+			virtual bool readContent();
+
+			virtual HttpResponse *createResponse() = 0;
+
+			virtual std::string readLine() = 0;
+			virtual void readRaw(char *buffer, int size) = 0;
+
+		private:
+			bool verbose;
+			bool valid;
+			bool blocking;
+			HttpResponse *response;
+
+			std::string method;
+			std::string uri;
+			std::string protocol;
+			std::vector<std::string> tokens;
+			std::map<std::string, std::string> headers;
+			std::string content;
+	};
+
+	class DashelHttpRequest : public HttpRequest
+	{
+		public:
+    		DashelHttpRequest(Dashel::Stream *stream);
+			virtual ~DashelHttpRequest();
+
+			virtual Dashel::Stream *getStream() { return stream; }
+
+		protected:
+			virtual HttpResponse *createResponse();
+
+			virtual std::string readLine();
+			virtual void readRaw(char *buffer, int size);
+
+		private:
+			Dashel::Stream *stream;
+	};
+}
+
+#endif

--- a/switches/http/HttpResponse.cpp
+++ b/switches/http/HttpResponse.cpp
@@ -119,7 +119,9 @@ void HttpResponse::addHeadersReply(std::ostringstream& reply)
 	map<string, string>::const_iterator end = headers.end();
 	for(map<string, string>::const_iterator iter = headers.begin(); iter != end; ++iter) {
 		if(iter->first == "Content-Length") { // override with actual size
-			reply << iter->first << ": " << content.size() << "\r\n";
+			if(getHeader("Content-Type") != "text/event-stream") { // but only if this is not an event stream
+				reply << iter->first << ": " << content.size() << "\r\n";
+			}
 		} else {
 			reply << iter->first << ": " << iter->second << "\r\n";
 		}

--- a/switches/http/HttpResponse.cpp
+++ b/switches/http/HttpResponse.cpp
@@ -1,0 +1,129 @@
+/*
+	Aseba - an event-based framework for distributed robot control
+	Copyright (C) 2007--2015:
+		Stephane Magnenat <stephane at magnenat dot net>
+		(http://stephane.magnenat.net)
+		and other contributors, see authors.txt for details
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, version 3 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <iostream>
+#include "HttpResponse.h"
+
+using Aseba::HttpRequest;
+using Aseba::HttpResponse;
+using std::cerr;
+using std::endl;
+using std::map;
+using std::ostringstream;
+using std::string;
+
+HttpResponse::HttpResponse(const HttpRequest *originatingRequest_) :
+	originatingRequest(originatingRequest_),
+	verbose(false),
+	status(HTTP_STATUS_OK)
+{
+	// add some default headers, these can be overwritten later
+	setHeader("Content-Length", "");
+	setHeader("Content-Type", "application/json");
+	setHeader("Access-Control-Allow-Origin", "*");
+
+	if(originatingRequest->getHeader("Connection") == "keep-alive") {
+		setHeader("Connection", "keep-alive");
+	}
+}
+
+HttpResponse::~HttpResponse()
+{
+
+}
+
+void HttpResponse::send()
+{
+	// send reply with status and headers first
+	ostringstream reply;
+
+	addStatusReply(reply);
+	addHeadersReply(reply);
+
+	std::string replyString(reply.str());
+	writeRaw(replyString.c_str(), replyString.size());
+
+	// send content payload second
+	writeRaw(content.c_str(), content.size());
+
+	if(verbose) {
+		cerr << getOriginatingRequest() << " Sent HTTP response with status " << status << " and " << content.size() << " byte(s) payload" << endl;
+	}
+}
+
+void HttpResponse::addStatusReply(std::ostringstream& reply)
+{
+	if(originatingRequest->getProtocol() == "HTTP/1.0" || originatingRequest->getProtocol() == "HTTP/1.1") {
+		reply << originatingRequest->getProtocol();
+	} else {
+		reply << "HTTP/1.1";
+	}
+
+	reply << " " << status << " ";
+
+	switch(status) {
+		case HTTP_STATUS_OK:
+			reply << "OK";
+		break;
+		case HTTP_STATUS_CREATED:
+			reply << "Created";
+		break;
+		case HTTP_STATUS_BAD_REQUEST:
+			reply << "Bad Request";
+		break;
+		case HTTP_STATUS_FORBIDDEN:
+			reply << "Forbidden";
+		break;
+		case HTTP_STATUS_NOT_FOUND:
+			reply << "Not Found";
+		break;
+		case HTTP_STATUS_REQUEST_TIMEOUT:
+			reply << "Request Timeout";
+		break;
+		case HTTP_STATUS_INTERNAL_SERVER_ERROR:
+			reply << "Internal Server Error";
+		break;
+		case HTTP_STATUS_NOT_IMPLEMENTED:
+			reply << "Not Implemented";
+		break;
+		case HTTP_STATUS_SERVICE_UNAVAILABLE:
+			reply << "Service Unavailable";
+		break;
+		default:
+			reply << "Unknown";
+		break;
+	}
+
+	reply << "\r\n";
+}
+
+void HttpResponse::addHeadersReply(std::ostringstream& reply)
+{
+	map<string, string>::const_iterator end = headers.end();
+	for(map<string, string>::const_iterator iter = headers.begin(); iter != end; ++iter) {
+		if(iter->first == "Content-Length") { // override with actual size
+			reply << iter->first << ": " << content.size() << "\r\n";
+		} else {
+			reply << iter->first << ": " << iter->second << "\r\n";
+		}
+	}
+
+	reply << "\r\n";
+}

--- a/switches/http/HttpResponse.h
+++ b/switches/http/HttpResponse.h
@@ -1,0 +1,113 @@
+/*
+	Aseba - an event-based framework for distributed robot control
+	Copyright (C) 2007--2015:
+		Stephane Magnenat <stephane at magnenat dot net>
+		(http://stephane.magnenat.net)
+		and other contributors, see authors.txt for details
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, version 3 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ASEBA_HTTP_RESPONSE
+#define ASEBA_HTTP_RESPONSE
+
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <dashel/dashel.h>
+
+#include "HttpRequest.h"
+
+namespace Aseba
+{
+	class HttpResponse
+	{
+		public:
+			typedef enum {
+				HTTP_STATUS_OK = 200,
+				HTTP_STATUS_CREATED = 201,
+				HTTP_STATUS_BAD_REQUEST = 400,
+				HTTP_STATUS_FORBIDDEN = 403,
+				HTTP_STATUS_NOT_FOUND = 404,
+				HTTP_STATUS_REQUEST_TIMEOUT = 408,
+				HTTP_STATUS_INTERNAL_SERVER_ERROR = 500,
+				HTTP_STATUS_NOT_IMPLEMENTED = 501,
+				HTTP_STATUS_SERVICE_UNAVAILABLE = 503,
+			} HttpStatus;
+
+			HttpResponse(const HttpRequest *originatingRequest);
+			virtual ~HttpResponse();
+
+			virtual void send();
+
+			virtual const HttpRequest *getOriginatingRequest() const { return originatingRequest; }
+			virtual void setVerbose(bool verbose) { this->verbose = verbose; }
+
+			virtual void setStatus(HttpStatus status) { this->status = status; }
+			virtual HttpStatus getStatus() const { return status; }
+			virtual void setHeader(const std::string& header, const std::string& value) { headers[header] = value; }
+			virtual const std::map<std::string, std::string>& getHeaders() const { return headers; }
+			virtual void setContent(const std::string& content) { this->content = content; }
+			virtual const std::string& getContent() const { return content; }
+
+			std::string getHeader(const std::string& header) const {
+				std::map<std::string, std::string>::const_iterator query = headers.find(header);
+
+				if(query != headers.end()) {
+					return query->second;
+				} else {
+					return "";
+				}
+			}
+
+		protected:
+			virtual void addStatusReply(std::ostringstream& reply);
+			virtual void addHeadersReply(std::ostringstream& reply);
+
+			virtual void writeRaw(const char *buffer, int length) = 0;
+
+		private:
+			const HttpRequest *originatingRequest;
+			bool verbose;
+
+			HttpStatus status;
+			std::map<std::string, std::string> headers;
+			std::string content;
+	};
+
+	class DashelHttpResponse : public HttpResponse
+	{
+		public:
+			DashelHttpResponse(DashelHttpRequest *originatingRequest) :
+				HttpResponse(originatingRequest),
+				stream(originatingRequest->getStream())
+			{
+
+			}
+
+			virtual ~DashelHttpResponse() {}
+
+		protected:
+			virtual void writeRaw(const char *buffer, int length)
+			{
+				stream->write(buffer, length);
+				stream->flush();
+			}
+
+		private:
+			Dashel::Stream *stream;
+	};
+}
+
+#endif

--- a/switches/http/http.cpp
+++ b/switches/http/http.cpp
@@ -658,6 +658,7 @@ namespace Aseba
         req->respond().setHeader("Content-Type", "text/event-stream");
         req->respond().setHeader("Cache-Control", "no-cache");
         req->respond().setHeader("Connection", "keep-alive");
+        req->respond().send(); // send header immediately
         req->setBlocking(true); // connection must stay open!
     }
     

--- a/switches/http/http.cpp
+++ b/switches/http/http.cpp
@@ -421,7 +421,9 @@ namespace Aseba
                 if (subscriber->second.count("*") >= 1 || subscriber->second.count(event_name) >= 1)
                 {
                 	std::string replyString(reply.str());
-                	static_cast<DashelHttpRequest *>(subscriber->first)->getStream()->write(replyString.c_str(), replyString.size());
+                	Dashel::Stream *stream = static_cast<DashelHttpRequest *>(subscriber->first)->getStream();
+                	stream->write(replyString.c_str(), replyString.size());
+                	stream->flush();
                 }
             }
         }


### PR DESCRIPTION
**Important: This PR depends on #16  and asummes that PR has already been merged!**

Hi David,

Here's part two of my refactoring. Rather than dispatching new requests in `routeRequests()` and then passing them on to various `evXXX()` methods whithin `HttpInterface`, I created a new `HttpHandler` class hierarchy that allows handlers to be defined outside of `HttpInterface`. It supports matching with URI tokens as well as passing requests down a handler hierarchy (e.g. as in the `/nodes/thymio-II/motor.left.target` case). My hope is that this new class hierarchy will make it a lot easier to add more requests handlers to asebahttp in the future.

As before, I took special care not to touch the functionality of asebahttp, so everything should still function exactly as before. That said, the interface between the handlers in `HttpInterfaceHandlers` and the `HttpInterface` is not very clean right now since they access some of the `HttpInterface` internals over publicly exposed getters. I deliberately didn't change this yet to make the changes to the actual request handler code (now in the `handleRequest()` methods) minimal for this refactoring, but I think it should be done and I might get back to it.

Best,
Fabian
